### PR TITLE
Update data selectors and dispatchers to `core/block-editor` for WP 5.3

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,8 +135,8 @@ export const unregisterBlock = ( { name, settings, filters, styles } ) => {
  * Store the selected block to persist selection across block-swaps.
  */
 export const beforeUpdateBlocks = () => {
-	selectedBlockId = data.select( 'core/editor' ).getSelectedBlockClientId();
-	data.dispatch( 'core/editor' ).clearSelectedBlock();
+	selectedBlockId = data.select( 'core/block-editor' ).getSelectedBlockClientId();
+	data.dispatch( 'core/block-editor' ).clearSelectedBlock();
 };
 
 /**
@@ -152,17 +152,17 @@ export const afterUpdateBlocks = ( changed = [] ) => {
 	}
 
 	// Refresh all blocks by iteratively selecting each one that has changed.
-	data.select( 'core/editor' ).getBlocks().forEach( ( { name, clientId } ) => {
+	data.select( 'core/block-editor' ).getBlocks().forEach( ( { name, clientId } ) => {
 		if ( changedNames.includes( name ) ) {
-			data.dispatch( 'core/editor' ).selectBlock( clientId );
+			data.dispatch( 'core/block-editor' ).selectBlock( clientId );
 		}
 	} );
 
 	// Reselect whatever was selected in the beginning.
 	if ( selectedBlockId ) {
-		data.dispatch( 'core/editor' ).selectBlock( selectedBlockId );
+		data.dispatch( 'core/block-editor' ).selectBlock( selectedBlockId );
 	} else {
-		data.dispatch( 'core/editor' ).clearSelectedBlock();
+		data.dispatch( 'core/block-editor' ).clearSelectedBlock();
 	}
 	selectedBlockId = null;
 };


### PR DESCRIPTION
WordPress 5.3 moved quite a few data selectors to `core/block-editor` and away from `core/editor`. This PR updates the store selectors to use the correct one and avoid the deprecation errors.

Ref: https://github.com/WordPress/gutenberg/blob/ab8af23410f9f89f5a57064b43758b157f392d55/packages/editor/CHANGELOG.md#940-2019-06-12