### PR TITLE
Allow block name to be passed as part of settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ src
 │       └── index.js
 └── blocks.js
 ```
-and that your block files export at minimum a `name` string and `settings` object:
+and that your block files export at minimum **either** a `settings` object and `name` string:
 
 ```js
 export const name = 'myplugin/block-a';
@@ -28,6 +28,19 @@ export const settings = {
 	description: 'An excellent example block',
 
 	// icon, category, attributes, edit, save, etcetera
+}
+
+```
+
+ **or** a `settings` object that has a `name` string property (e.g., when using `block.json` to manage your block's metadata):
+
+```js
+import metadata from './block.json';
+
+export const settings = {
+	...metadata
+
+	// edit, save, other dynamic data
 }
 
 ```

--- a/index.js
+++ b/index.js
@@ -93,12 +93,12 @@ let selectedBlockId = null;
  * Register a new or updated block.
  *
  * @param {Object}   block            The exported block module.
- * @param {String}   block.name       Block name.
  * @param {Object}   block.settings   Block configuration object.
+ * @param {String}   block.name       Block name. May be included in configuration.
  * @param {Object[]} [block.filters]  Optional array of filters to bind.
  * @param {Object[]} [block.styles]   Optional array of block styles to bind.
  */
-export const registerBlock = ( { name, settings, filters, styles } ) => {
+export const registerBlock = ( { settings, name = settings?.name, filters, styles } ) => {
 	if ( name && settings ) {
 		blocks.registerBlockType( name, settings );
 	}
@@ -118,12 +118,12 @@ export const registerBlock = ( { name, settings, filters, styles } ) => {
  * Unregister an updated or removed block.
  *
  * @param {Object}   block            The exported block module.
- * @param {String}   block.name       Block name.
  * @param {Object}   block.settings   Block configuration object.
+ * @param {String}   block.name       Block name. May be included in configuration.
  * @param {Object[]} [block.filters]  Optional array of filters to bind.
  * @param {Object[]} [block.styles]   Optional array of block styles to bind.
  */
-export const unregisterBlock = ( { name, settings, filters, styles } ) => {
+export const unregisterBlock = ( { settings, name = settings?.name, filters, styles } ) => {
 	if ( name && settings ) {
 		blocks.unregisterBlockType( name );
 	}


### PR DESCRIPTION
When using `block.json` for managing a block's metadata, the block's name is already a part of that file; it is the only required property, actually.

With the current version of this library, a minimal example for a block `index.js` file would look like so:

```js
import metadata from './block.json';
import edit from './edit';

export const { name } = metadata;

export const settings = {
	...metadata,
	edit,
};
```

Both the `name` and the `settings` exports are required.

This PR changes the `registerBlock` and `unregisterBlock` functions to have the `name` property of the module (i.e., exports) fall back to `settings.name`, if available.
This is a minimal change, and reduces the above example to this:

```js
import metadata from './block.json';
import edit from './edit';

export const settings = {
	...metadata,
	edit,
};
```

For this to work, I had to change the order of `name` and `settings` in the destructure expression (and I then also changed the parameter documentation accordingly).

I could also have `name` fall back to `settings?.name` **inside** the function, if you think that'd be better. 🤷‍♂️

I can include an updated `build.js` file, but wasn't sure which Node.js version we want this to be build with.