### PR TITLE
Allow autoloadBlocks to handle filters or styles without block object

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,17 +90,17 @@ export const autoload = (
 let selectedBlockId = null;
 
 /**
- * Register a new or updated block.
+ * Register a new or updated block, filters, or style variations.
  *
  * @param {Object}   block            The exported block module.
  * @param {String}   block.name       Block name. May be included in configuration object.
- * @param {Object}   block.settings   Block configuration object.
+ * @param {Object}   [block.settings] Optional block configuration object.
  * @param {Object[]} [block.filters]  Optional array of filters to bind.
  * @param {Object[]} [block.styles]   Optional array of block styles to bind.
  */
 export const registerBlock = ( { name, settings, filters, styles } ) => {
-	if ( ( name || settings.name ) && settings ) {
-		blocks.registerBlockType( ( name || settings.name ), settings );
+	if ( ( name || settings?.name ) && settings ) {
+		blocks.registerBlockType( ( name || settings?.name ), settings );
 	}
 
 	if ( filters && Array.isArray( filters ) ) {
@@ -115,17 +115,17 @@ export const registerBlock = ( { name, settings, filters, styles } ) => {
 };
 
 /**
- * Unregister an updated or removed block.
+ * Unregister an updated or removed block, filters, or style variations.
  *
  * @param {Object}   block            The exported block module.
  * @param {String}   block.name       Block name. May be included in configuration object.
- * @param {Object}   block.settings   Block configuration object.
+ * @param {Object}   [block.settings] Optional block configuration object.
  * @param {Object[]} [block.filters]  Optional array of filters to bind.
  * @param {Object[]} [block.styles]   Optional array of block styles to bind.
  */
 export const unregisterBlock = ( { name, settings, filters, styles } ) => {
-	if ( ( name || settings.name ) && settings ) {
-		blocks.unregisterBlockType( ( name || settings.name ) );
+	if ( ( name || settings?.name ) && settings ) {
+		blocks.unregisterBlockType( ( name || settings?.name ) );
 	}
 
 	if ( filters && Array.isArray( filters ) ) {


### PR DESCRIPTION
Before a recent change, it was possible to use the `autoloadBlocks` functionality to register filters or styles without actually exporting a block settings object. (I don't know if it was a good idea to do so, but it was possible and convenient. In one project I used this to register filters on core blocks without re-registering the blocks, and it was nice to be able to keep those core block modifications in the same directory as project-specific custom blocks.) 

Anyhow, 2252caa97 broke that functionality, causing an uncaught type error if a file passed to `autoloadBlocks()` didn't export a `settings` object. 

This commit avoids that error by adding a null check on the `settings` object before trying to access it.