### PR TITLE
V1: Introduce slimmer wp-scripts-oriented API

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,6 @@ and that you are [building your project into per-block bundles using `wp-scripts
 The standard boilerplate expected by this utility can be seen at the bottom of this example block `index.js`:
 
 ```js
-/**
- * An expandable "accordion item".
- *
- * Child block of the "shiro/accordion" wrapper block.
- */
-
-/**
- * WordPress dependencies
- */
 import { registerBlockType } from '@wordpress/blocks';
 
 import metadata from './block.json';
@@ -45,7 +36,6 @@ registerBlockType( metadata.name, {
 	...metadata,
 	edit,
 	save,
-	deprecated,
 } );
 
 // Block HMR boilerplate.

--- a/README.md
+++ b/README.md
@@ -68,3 +68,7 @@ If we try to register a block without unregistering it first, the block editor t
 ### Can we simplify that boilerplate?
 
 It's possible this could be simplified further, but testing to date indicates that `module.hot.accept` _must_ be called from the entrypoint file within your project, rather than being abstracted within the third-party NPM module.
+
+## What if I do not use per-block bundles?
+
+While we recommend following `wp-scripts`' preferred structure and bundling your JS at the level of an individual block (for both performance and maintainability reasons), if you do still use a kitchen-sink bundle for all of your blocks, [you may prefer to stick with the legacy `v0.7.0` API documented here](https://github.com/kadamwhite/block-editor-hmr/tree/684b63e60208f047703ddebf0f8f351525e4bebe/README.md).

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -47,7 +47,7 @@ module.exports = [
 			'curly': 'error',
 			'default-case': 'error',
 			'default-param-last': 'error',
-			'dot-location': 'error',
+			'dot-location': [ 'error', 'property' ],
 			'dot-notation': 'error',
 			'eol-last': 'error',
 			'eqeqeq': 'error',

--- a/index.js
+++ b/index.js
@@ -1,412 +1,68 @@
 /**
- * Provide helper methods to dynamically locate, load & register Blocks & Plugins.
+ * Provide helper methods to dynamically reload & reregister blocks in hot-reloading contexts.
  */
-const {
-	blocks,
-	plugins,
-	richText,
-	hooks,
-	data,
-} = window.wp;
+const { unregisterBlockType, unregisterBlockStyle } = window.wp.blocks;
+const { removeFilter } = window.wp.hooks;
+const { dispatch, select } = window.wp.data;
 
 /**
- * No-op function for use as a default argument value.
- */
-const noop = () => {};
-
-/**
- * Require a set of modules and configure them for hot module replacement.
- * The consuming function must opt-in to HMR by passing a callback to
- * accept updates for the context where this function is used.
+ * Deregister a block that's being hot-swapped out, so that the updated version
+ * can be registered afresh without "block already registered" errors.
  *
- * The first argument should be a function returning a `require.context()`
- * call. All modules loaded from this context are cached, and on each rebuild
- * the incoming updated modules are checked against the cache. Updated modules
- * which already exist in the cache are unregistered with the provided function,
- * then any incoming (new or updated) modules will be registered.
+ * Also keeps track of the selected block client ID, which is needed because
+ * we have to deselect a block before unregistering it to swap without error.
+ * The active block will be reselected in the refresh function.
  *
- * @param {object}   options            Configuration object defining callbacks.
- * @param {Function} options.getContext Execute and return a `require.context()` call.
- * @param {Function} options.register   Function to register accepted modules.
- * @param {Function} options.unregister Function to unregister replaced modules.
- * @param {Function} [options.before]   Function to run before updating modules.
- * @param {Function} [options.after]    Function to run after updating modules.
- * @param {Function} [callback]         A callback function which will be passed the
- *                                      generated `context` object and `loadModules`
- *                                      function, which can be used to opt-in to HMR.
+ * @param {string} hotBlockName Name of block being hot-reloaded.
+ * @param {object} [variants]   Dictionary of { styles, filters } arrays to optionally unbind.
+ * @returns {(data: object) => void} Callback for module.hot.dispose() to deregister the specified block.
  */
-export const autoload = (
-	{
-		getContext,
-		register,
-		unregister,
-		before = noop,
-		after = noop,
-	},
-	callback = noop
-) => {
-	const cache = {};
-	const loadModules = () => {
-		before();
+export const deregisterBlock = ( hotBlockName, variants = {} ) => ( data ) => {
+	unregisterBlockType( hotBlockName );
 
-		const context = getContext();
-		const changed = [];
-		context.keys().forEach( ( key ) => {
-			const module = context( key );
-			if ( module === cache[ key ] ) {
-				// Module unchanged: no further action needed.
-				return;
-			}
-			const isHotUpdate = cache[ key ];
-			if ( isHotUpdate && console.groupCollapsed ) {
-				console.groupCollapsed( `hot update: ${ key }` );
-			}
-			if ( isHotUpdate ) {
-				// Module changed, and prior copy detected: unregister old module.
-				unregister( cache[ key ] );
-			}
-			// Register new module and update cache.
-			register( module );
-			changed.push( module );
-			cache[ key ] = module;
-
-			if ( isHotUpdate && console.groupCollapsed ) {
-				console.groupEnd();
-			}
-		} );
-
-		after( changed );
-
-		// Return the context for HMR initialization.
-		return context;
-	};
-
-	const context = loadModules();
-
-	callback( context, loadModules );
-};
-
-// Maintain the selected block ID across HMR updates.
-let selectedBlockId = null;
-
-/**
- * Register a new or updated block, filters, or style variations.
- *
- * @param {object}   block            The exported block module.
- * @param {string}   block.name       Block name. May be included in configuration object.
- * @param {object}   [block.settings] Optional block configuration object.
- * @param {object[]} [block.filters]  Optional array of filters to bind.
- * @param {object[]} [block.styles]   Optional array of block styles to bind.
- */
-export const registerBlock = ( { name, settings, filters, styles } ) => {
-	if ( ( name || settings?.name ) && settings ) {
-		blocks.registerBlockType( ( name || settings?.name ), settings );
-	}
-
-	if ( filters && Array.isArray( filters ) ) {
-		filters.forEach( ( { hook, namespace, callback } ) => {
-			hooks.addFilter( hook, namespace, callback );
+	if ( Array.isArray( variants?.styles ) ) {
+		variants.styles.forEach( ( style ) => {
+			unregisterBlockStyle( hotBlockName, style.name );
 		} );
 	}
 
-	if ( styles && Array.isArray( styles ) ) {
-		styles.forEach( ( style ) => blocks.registerBlockStyle( name, style ) );
-	}
-};
-
-/**
- * Unregister an updated or removed block, filters, or style variations.
- *
- * @param {object}   block            The exported block module.
- * @param {string}   block.name       Block name. May be included in configuration object.
- * @param {object}   [block.settings] Optional block configuration object.
- * @param {object[]} [block.filters]  Optional array of filters to bind.
- * @param {object[]} [block.styles]   Optional array of block styles to bind.
- */
-export const unregisterBlock = ( { name, settings, filters, styles } ) => {
-	if ( ( name || settings?.name ) && settings ) {
-		blocks.unregisterBlockType( ( name || settings?.name ) );
-	}
-
-	if ( filters && Array.isArray( filters ) ) {
-		filters.forEach( ( { hook, namespace } ) => {
-			hooks.removeFilter( hook, namespace );
+	if ( Array.isArray( variants?.filters ) ) {
+		variants.filters.forEach( ( { hook, namespace } ) => {
+			removeFilter( hook, namespace );
 		} );
 	}
 
-	if ( styles && Array.isArray( styles ) ) {
-		styles.forEach( ( style ) => blocks.unregisterBlockStyle( name, style.name ) );
-	}
-};
+	const selectedBlockId = select( 'core/block-editor' ).getSelectedBlockClientId();
 
-/**
- * Store the selected block to persist selection across block-swaps.
- */
-export const beforeUpdateBlocks = () => {
-	selectedBlockId = data.select( 'core/block-editor' ).getSelectedBlockClientId();
-	data.dispatch( 'core/block-editor' ).clearSelectedBlock();
-};
-
-/**
- * Trigger a re-render on all blocks which have changed.
- *
- * @param {object[]} changed Array of changed module objects.
- */
-export const afterUpdateBlocks = ( changed = [] ) => {
-	const changedNames = changed.map( ( module ) => module.name );
-
-	if ( ! changedNames.length ) {
-		return;
-	}
-
-	// Refresh all blocks by iteratively selecting each one that has changed.
-	data.select( 'core/block-editor' ).getBlocks().forEach( ( { name, clientId } ) => {
-		if ( changedNames.includes( name ) ) {
-			data.dispatch( 'core/block-editor' ).selectBlock( clientId );
-		}
-	} );
-
-	// Reselect whatever was selected in the beginning.
 	if ( selectedBlockId ) {
-		data.dispatch( 'core/block-editor' ).selectBlock( selectedBlockId );
-	} else {
-		data.dispatch( 'core/block-editor' ).clearSelectedBlock();
-	}
-	selectedBlockId = null;
-};
-
-/**
- * Require a set of blocks and configure them for hot module replacement.
- *
- * @see autoload
- *
- * @param {object}   options              Configuration object defining callbacks.
- * @param {Function} options.getContext   Execute and return a `require.context()` call.
- * @param {Function} [options.register]   Function to register accepted blocks.
- * @param {Function} [options.unregister] Function to unregister replaced blocks.
- * @param {Function} [options.before]     Function to run before updating blocks.
- * @param {Function} [options.after]      Function to run after updating blocks.
- * @param {Function} [callback]           A callback function which will be passed the
- *                                        generated `context` object and `loadModules`
- *                                        function, which can be used to opt-in to HMR.
- */
-export const autoloadBlocks = (
-	{
-		getContext,
-		register = registerBlock,
-		unregister = unregisterBlock,
-		before = beforeUpdateBlocks,
-		after = afterUpdateBlocks,
-	},
-	callback
-) => {
-	autoload(
-		{
-			getContext,
-			register,
-			unregister,
-			before,
-			after,
-		},
-		callback
-	);
-};
-
-/**
- * Register a new or updated plugin.
- *
- * @param {object}   plugin           The exported plugin module.
- * @param {string}   plugin.name      Plugin name.
- * @param {object}   plugin.settings  Plugin configuration object.
- * @param {object[]} [plugin.filters] Optional array of filters to bind.
- */
-export const registerPlugin = ( { name, settings, filters } ) => {
-	if ( name && settings ) {
-		plugins.registerPlugin( name, settings );
+		dispatch( 'core/block-editor' ).clearSelectedBlock();
 	}
 
-	if ( filters && Array.isArray( filters ) ) {
-		filters.forEach( ( { hook, namespace, callback } ) => {
-			hooks.addFilter( hook, namespace, callback );
-		} );
-	}
+	// Pass selected ID through hot-reload cycle.
+	data.value = selectedBlockId;
 };
 
 /**
- * Unregister an updated or removed plugin.
+ * Process an updated block module, refreshing the editor view as needed.
  *
- * @param {object}   plugin           The exported plugin module.
- * @param {string}   plugin.name      Plugin name.
- * @param {object}   plugin.settings  Plugin configuration object.
- * @param {object[]} [plugin.filters] Optional array of filters to bind.
+ * @param {string}           hotBlockName Name of block being hot-reloaded.
+ * @param {{value?: string}} [data]       HMR module.hot.data context object, if present.
  */
-export const unregisterPlugin = ( { name, settings, filters } ) => {
-	if ( name && settings ) {
-		plugins.unregisterPlugin( name );
-	}
-
-	if ( filters && Array.isArray( filters ) ) {
-		filters.forEach( ( { hook, namespace } ) => {
-			hooks.removeFilter( hook, namespace );
-		} );
-	}
-};
-
-/**
- * Require a set of plugins and configure them for hot module replacement.
- *
- * @see autoload
- *
- * @param {object}   options              Configuration object defining callbacks.
- * @param {Function} options.getContext   Execute and return a `require.context()` call.
- * @param {Function} [options.register]   Function to register accepted plugins.
- * @param {Function} [options.unregister] Function to unregister replaced plugins.
- * @param {Function} [options.before]     Function to run before updating plugins.
- * @param {Function} [options.after]      Function to run after updating plugins.
- * @param {Function} [callback]           A callback function which will be passed the
- *                                        generated `context` object and `loadModules`
- *                                        function, which can be used to opt-in to HMR.
- */
-export const autoloadPlugins = (
-	{
-		getContext,
-		register = registerPlugin,
-		unregister = unregisterPlugin,
-		before,
-		after,
-	},
-	callback
-) => {
-	autoload(
-		{
-			getContext,
-			register,
-			unregister,
-			before,
-			after,
-		},
-		callback
-	);
-};
-
-/**
- * Register a new or updated format type
- *
- * @param {object}   format           The exported format module.
- * @param {string}   format.name      Format type name.
- * @param {object}   format.settings  Format type configuration object.
- */
-export const registerFormat = ( { name, settings } ) => {
-	if ( name && settings ) {
-		richText.registerFormatType( name, settings );
-	}
-};
-
-/**
- * Unregister an updated or removed format type.
- *
- * @param {object}   format           The exported format module.
- * @param {string}   format.name      Format type name.
- * @param {object}   format.settings  Format type configuration object.
- */
-export const unregisterFormat = ( { name, settings } ) => {
-	if ( name && settings ) {
-		richText.unregisterFormatType( name );
-	}
-};
-
-/**
- * Require a set of format types and configure them for hot module replacement.
- *
- * @see autoload
- *
- * @param {object}   options              Configuration object defining callbacks.
- * @param {Function} options.getContext   Execute and return a `require.context()` call.
- * @param {Function} [options.register]   Function to register accepted formats.
- * @param {Function} [options.unregister] Function to unregister replaced formats.
- * @param {Function} [options.before]     Function to run before updating formats.
- * @param {Function} [options.after]      Function to run after updating formats.
- * @param {Function} [callback]           A callback function which will be passed the
- *                                        generated `context` object and `loadModules`
- *                                        function, which can be used to opt-in to HMR.
- */
-export const autoloadFormats = (
-	{
-		getContext,
-		register = registerFormat,
-		unregister = unregisterFormat,
-		before,
-		after,
-	},
-	callback
-) => {
-	autoload(
-		{
-			getContext,
-			register,
-			unregister,
-			before,
-			after,
-		},
-		callback
-	);
-};
-
-/* eslint-disable no-underscore-dangle */
-/* eslint-disable camelcase */
-/**
- * Work around a full-page crash in WordPress 5.4 caused by a forced render of
- * the BlockListBlock component following the state dispatch triggered upon block
- * unregistration.
- *
- * This function filters the BlockListBlock component to wrap it in an error
- * boundary, which catches the error when BlockListBlock tries to access a
- * property on the removed block type, suppresses the error by returning null,
- * and then schedules the BlockListBlock to try rendering again on the next
- * tick (by which point our hot-swapped block type should be available again).
- */
-export const _apply_wp_5_4_hmr_patch = () => {
-	/* eslint-enable */
-	const React = window.React;
-	const { Component, Fragment, createElement } = React;
-
-	hooks.addFilter(
-		'editor.BlockListBlock',
-		'block-editor-hmr/prevent-block-swapping-error',
-		( BlockListBlock ) => {
-			class ErrorWrapper extends Component {
-				constructor( props ) {
-					super( props );
-					this.state = { hasError: false };
-				}
-
-				// eslint-disable-next-line no-unused-vars
-				static getDerivedStateFromError( error ) {
-					return { hasError: true };
-				}
-
-				componentDidUpdate( prevProps, prevState ) {
-					if ( this.state.hasError && this.state.hasError !== prevState.hasError ) {
-						setTimeout( () => {
-							this.setState( { hasError: false } );
-						} );
-					}
-				}
-
-				render() {
-					if ( this.state.hasError ) {
-						return null;
-					}
-
-					return createElement(
-						Fragment,
-						null,
-						createElement( BlockListBlock, this.props )
-					);
-				}
+export const refreshEditor = ( hotBlockName, data ) => {
+	// Refresh all copies of our changed block by iteratively selecting them.
+	select( 'core/block-editor' )
+		.getBlocks()
+		.forEach( ( { name, clientId } ) => {
+			if ( name === hotBlockName ) {
+				dispatch( 'core/block-editor' ).selectBlock( clientId );
 			}
+		} );
 
-			return ErrorWrapper;
-		}
-	);
+	// Reselect whatever block was selected in the beginning.
+	if ( data?.value ) {
+		// Reselect after a timeout to finish hot-block processing before changing focus.
+		setTimeout( () => {
+			dispatch( 'core/block-editor' ).selectBlock( data.value );
+		} );
+	}
 };


### PR DESCRIPTION
For #13

Implements a new API designed for use within individual block modules, rather than the previous `autoload` system:

- `deregisterBlock( blockName: string, variants: ?object ) => ( data: object ) => void`
  - Unregister a block before the HMR swap for its module to prevent double-registration
  - Called as `module.hot.dispose( deregister( metadata.name ) );` within the `if ( module.hot ) {}` block
- `refresh( blockName: string, data: object ) => void`
  - Reselect the currently-active block (if present) after the HMR swap, to retain editor context
  - Called as `refresh( name, module.hot.data )` within the `if ( module.hot ) {}` block

This version of the API has been in active use in the Wikimedia Foundation's "Shiro" WordPress theme and a variety of other projects, so while it is very limited versus the prior autoloader API, it does hold up in a modern wp-scripts-oriented block setup.