### PR TITLE
Prepare v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   },
   "keywords": [
     "webpack",
+    "wordpress",
+    "gutenberg",
     "hmr"
   ],
   "author": "K Adam White",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "block-editor-hmr",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0",
   "description": "Utilities to autoload and hot-reload WordPress Block Editor modules.",
   "main": "build.js",
   "homepage": "https://github.com/kadamwhite/block-editor-hmr#readme",


### PR DESCRIPTION
We've been using beta.2 for some time now, let's tag the stable 🚀 

No code changes since #20 (beta.2)